### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" 
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
If you do not know already, dependabot helps the project with dependency updates. It creates a PR for each npm package that can be updated.
To activate the dependabot a maintainer has to enable the feature under Settings -> Code security and analysis then in the Dependabot section the "dependabot version updates". 

![image](https://github.com/TUM-Dev/TUMenu/assets/10695477/4e6e61de-170b-4369-b8d4-f86a59c930ec)

The config that I added currently proposes updates weekly for all packages in the root package.json