### PR TITLE
Fix date format

### DIFF
--- a/components/LanguageSwitcher.jsx
+++ b/components/LanguageSwitcher.jsx
@@ -11,10 +11,7 @@ const LanguageSwitchLink = ({ locale, ...rest }) => {
   const { t } = useTranslation('common')
 
   const handleLanguageChange = (newLocale) => {
-    localStorage.setItem('appLocale', newLocale);
-    languageDetector.cache(newLocale);
-
-    // Trigger a custom event
+    router.push(router.pathname, router.asPath, { locale: newLocale });
     const event = new CustomEvent('languageChange', { detail: { locale: newLocale } });
     window.dispatchEvent(event);
   };

--- a/components/LanguageSwitcher.jsx
+++ b/components/LanguageSwitcher.jsx
@@ -10,6 +10,15 @@ const LanguageSwitchLink = ({ locale, ...rest }) => {
   const theme = useTheme()
   const { t } = useTranslation('common')
 
+  const handleLanguageChange = (newLocale) => {
+    localStorage.setItem('appLocale', newLocale);
+    languageDetector.cache(newLocale);
+
+    // Trigger a custom event
+    const event = new CustomEvent('languageChange', { detail: { locale: newLocale } });
+    window.dispatchEvent(event);
+  };
+
   let href = rest.href || router.asPath
   let pName = router.pathname
   Object.keys(router.query).forEach((k) => {
@@ -40,7 +49,7 @@ const LanguageSwitchLink = ({ locale, ...rest }) => {
         </Typography>
       </Grid>
       <Grid item xs={4}>
-        <Link href={href} onClick={() => languageDetector.cache(locale)}>
+        <Link href={href} onClick={() => handleLanguageChange(locale)}>
           <button
             style={{
               fontSize: theme.spacing(3),

--- a/components/Layout/DatePicker.tsx
+++ b/components/Layout/DatePicker.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import dayjs, { Dayjs } from 'dayjs'
-import 'dayjs/locale/de' // import German locale
-import 'dayjs/locale/en' // import English locale
+import 'dayjs/locale/de'
+import 'dayjs/locale/en'
 import TextField from '@mui/material/TextField'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
@@ -38,7 +38,7 @@ export default function HeaderDatePicker({
       window.addEventListener('languageChange', handleLanguageChange);
 
       // Initial locale setup
-      const currentLocale = localStorage.getItem('appLocale') || 'en';
+      const currentLocale = localStorage.getItem('i18nextLng') || 'en';
       setLocale(currentLocale);
       dayjs.locale(currentLocale);
 
@@ -68,7 +68,7 @@ export default function HeaderDatePicker({
         onChange={(newValue) => {
           if (dayjs(newValue).isValid()) datePickerSetValue(newValue)
         }}
-        inputFormat={getDateFormat()} // Moved inputFormat here
+        inputFormat={getDateFormat()}
         renderInput={(params) => (
           <TextField
             {...params}

--- a/components/Layout/DatePicker.tsx
+++ b/components/Layout/DatePicker.tsx
@@ -29,13 +29,13 @@ export default function HeaderDatePicker({
   const [locale, setLocale] = useState('en'); // default to English
 
     useEffect(() => {
-      const handleLanguageChange = (event) => {
+      const handleLanguageChange = (event: CustomEvent) => {
         const newLocale = event.detail.locale;
         setLocale(newLocale);
         dayjs.locale(newLocale);
       };
 
-      window.addEventListener('languageChange', handleLanguageChange);
+      window.addEventListener('languageChange', handleLanguageChange as EventListener);
 
       // Initial locale setup
       const currentLocale = localStorage.getItem('i18nextLng') || 'en';
@@ -43,7 +43,7 @@ export default function HeaderDatePicker({
       dayjs.locale(currentLocale);
 
       return () => {
-        window.removeEventListener('languageChange', handleLanguageChange);
+        window.removeEventListener('languageChange', handleLanguageChange as EventListener);
         };
       }, []);
 

--- a/components/Layout/DatePicker.tsx
+++ b/components/Layout/DatePicker.tsx
@@ -1,4 +1,7 @@
+import React, {useEffect, useState} from 'react';
 import dayjs, { Dayjs } from 'dayjs'
+import 'dayjs/locale/de' // import German locale
+import 'dayjs/locale/en' // import English locale
 import TextField from '@mui/material/TextField'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
@@ -23,9 +26,39 @@ export default function HeaderDatePicker({
   maxDate,
 }: HeaderDatePickerProps) {
   const theme = useTheme()
+  const [locale, setLocale] = useState('en'); // default to English
+
+    useEffect(() => {
+      const handleLanguageChange = (event) => {
+        const newLocale = event.detail.locale;
+        setLocale(newLocale);
+        dayjs.locale(newLocale);
+      };
+
+      window.addEventListener('languageChange', handleLanguageChange);
+
+      // Initial locale setup
+      const currentLocale = localStorage.getItem('appLocale') || 'en';
+      setLocale(currentLocale);
+      dayjs.locale(currentLocale);
+
+      return () => {
+        window.removeEventListener('languageChange', handleLanguageChange);
+        };
+      }, []);
+
+      const getDateFormat = () => {
+        switch (locale) {
+          case 'de':
+            return 'DD.MM.YYYY'; // German format
+          case 'en':
+          default:
+            return 'DD/MM/YYYY'; // English format
+        }
+      }
 
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs}>
+    <LocalizationProvider dateAdapter={AdapterDayjs} locale={locale}>
       <DatePicker
         closeOnSelect
         minDate={minDate}
@@ -35,12 +68,13 @@ export default function HeaderDatePicker({
         onChange={(newValue) => {
           if (dayjs(newValue).isValid()) datePickerSetValue(newValue)
         }}
+        inputFormat={getDateFormat()} // Moved inputFormat here
         renderInput={(params) => (
           <TextField
+            {...params}
             sx={{
               backgroundColor: theme.palette.secondary.main,
             }}
-            {...params}
           />
         )}
       />


### PR DESCRIPTION
The default date format on hunger.tum.sexy is a middle endian confusing date format.

In this Pull Request I have updated the date format to be use the English date format as default and also switch to the German date formal based on which language is selected.

English format:
<img width="338" alt="image" src="https://github.com/TUM-Dev/TUMenu/assets/25747019/e5d03bfb-177e-44a0-82cc-d7d6dd1342b1">


German format:
<img width="330" alt="image" src="https://github.com/TUM-Dev/TUMenu/assets/25747019/7e7958fd-9473-4032-ada3-38045fc012b4">
